### PR TITLE
List Pied Piper Coin (PPI)

### DIFF
--- a/src/main/java/bisq/asset/tokens/PiedPiperCoin.java
+++ b/src/main/java/bisq/asset/tokens/PiedPiperCoin.java
@@ -1,0 +1,27 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.asset.tokens;
+
+import bisq.asset.Erc20Token;
+
+public class PiedPiperCoin extends Erc20Token {
+
+    public PiedPiperCoin() {
+        super("Pied Piper Coin", "PPI");
+    }
+}

--- a/src/main/resources/META-INF/services/bisq.asset.Asset
+++ b/src/main/resources/META-INF/services/bisq.asset.Asset
@@ -109,6 +109,7 @@ bisq.asset.tokens.Internext
 bisq.asset.tokens.Movement
 bisq.asset.tokens.MyceliumToken
 bisq.asset.tokens.PascalCoin
+bisq.asset.tokens.PiedPiperCoin
 bisq.asset.tokens.Qwark
 bisq.asset.tokens.RefToken
 bisq.asset.tokens.SosCoin

--- a/src/test/java/bisq/asset/tokens/PiedPiperCoinTest.java
+++ b/src/test/java/bisq/asset/tokens/PiedPiperCoinTest.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.asset.tokens;
+
+import bisq.asset.AbstractAssetTest;
+
+import org.junit.Test;
+
+public class PiedPiperCoinTest extends AbstractAssetTest {
+
+    public PiedPiperCoinTest() {
+        super(new PiedPiperCoin());
+    }
+
+    @Test
+    public void testValidAddresses() {
+        assertValidAddress("0x2a65Aca4D5fC5B5C859090a6c34d164135398226");
+        assertValidAddress("2a65Aca4D5fC5B5C859090a6c34d164135398226");
+    }
+
+    @Test
+    public void testInvalidAddresses() {
+        assertInvalidAddress("0x2a65Aca4D5fC5B5C859090a6c34d1641353982266");
+        assertInvalidAddress("0x2a65Aca4D5fC5B5C859090a6c34d16413539822g");
+        assertInvalidAddress("2a65Aca4D5fC5B5C859090a6c34d16413539822g");
+    }
+}


### PR DESCRIPTION
- Official project URL: http://www.piedpiper.com/
 - Official block explorer URL: https://etherscan.io/

Note: There is no dedicated block explorer for PPI, but because it's an
ERC20 token, any Ethereum block explorer will do, thus the link to
Etherscan.