### PR TITLE
Check bisq.asset.Asset file sorting during CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk: oraclejdk8
-before_install: sort --check --ignore-case src/main/resources/META-INF/services/bisq.asset.Asset
+before_install: sort --check --dictionary-order --ignore-case src/main/resources/META-INF/services/bisq.asset.Asset
 notifications:
   slack:
     on_success: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 jdk: oraclejdk8
+before_install: sort --check --ignore-case src/main/resources/META-INF/services/bisq.asset.Asset
 notifications:
   slack:
     on_success: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 jdk: oraclejdk8
-before_install: sort --check --dictionary-order --ignore-case src/main/resources/META-INF/services/bisq.asset.Asset
+before_install:
+  grep -v '^#' src/main/resources/META-INF/services/bisq.asset.Asset | sort --check --dictionary-order --ignore-case
 notifications:
   slack:
     on_success: change

--- a/src/main/resources/META-INF/services/bisq.asset.Asset
+++ b/src/main/resources/META-INF/services/bisq.asset.Asset
@@ -1,16 +1,12 @@
-# All assets available for trading on the Bisq network.
-# Contents are sorted according to the output of `sort --ignore-case`.
-# See bisq.asset.Asset and bisq.asset.AssetRegistry for further details.
-# See https://bisq.network/list-asset for complete instructions.
 bisq.asset.coins.Achievecoin
 bisq.asset.coins.Angelcoin
 bisq.asset.coins.Arto
-bisq.asset.coins.Bitcoin$Mainnet
-bisq.asset.coins.Bitcoin$Regtest
-bisq.asset.coins.Bitcoin$Testnet
 bisq.asset.coins.BitcoinCash
 bisq.asset.coins.BitcoinClashic
 bisq.asset.coins.BitcoinGold
+bisq.asset.coins.Bitcoin$Mainnet
+bisq.asset.coins.Bitcoin$Regtest
+bisq.asset.coins.Bitcoin$Testnet
 bisq.asset.coins.Bitcore
 bisq.asset.coins.BitDaric
 bisq.asset.coins.BitZeny
@@ -48,10 +44,10 @@ bisq.asset.coins.Koto
 bisq.asset.coins.Kumacoin
 bisq.asset.coins.LBRY
 bisq.asset.coins.Lisk
+bisq.asset.coins.LitecoinExtreme
 bisq.asset.coins.Litecoin$Mainnet
 bisq.asset.coins.Litecoin$Regtest
 bisq.asset.coins.Litecoin$Testnet
-bisq.asset.coins.LitecoinExtreme
 bisq.asset.coins.Madbyte
 bisq.asset.coins.Madcoin
 bisq.asset.coins.MaidSafeCoin

--- a/src/main/resources/META-INF/services/bisq.asset.Asset
+++ b/src/main/resources/META-INF/services/bisq.asset.Asset
@@ -1,3 +1,7 @@
+# All assets available for trading on the Bisq network.
+# Contents are sorted according to the output of `sort --ignore-case --dictionary-order`.
+# See bisq.asset.Asset and bisq.asset.AssetRegistry for further details.
+# See https://bisq.network/list-asset for complete instructions.
 bisq.asset.coins.Achievecoin
 bisq.asset.coins.Angelcoin
 bisq.asset.coins.Arto


### PR DESCRIPTION
_(edited by @cbeams)_:

This PR is to deal with several ordering issues that crept into the file over time. So far we've only been eyeballing sort order during PR review, and we missed a few items, so now is a good time to automate checking the sort order via Travis CI.