### PR TITLE
List Bitcoin Core (BTCC)

### DIFF
--- a/src/main/java/bisq/asset/coins/BitcoinCore.java
+++ b/src/main/java/bisq/asset/coins/BitcoinCore.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.asset.coins;
+
+import bisq.asset.Base58BitcoinAddressValidator;
+import bisq.asset.Coin;
+
+public class BitcoinCore extends Coin {
+
+    public BitcoinCore() {
+        super("Bitcoin Core", "BTCC", new Base58BitcoinAddressValidator());
+    }
+}

--- a/src/main/resources/META-INF/services/bisq.asset.Asset
+++ b/src/main/resources/META-INF/services/bisq.asset.Asset
@@ -8,6 +8,7 @@ bisq.asset.coins.Aquachain
 bisq.asset.coins.Arto
 bisq.asset.coins.BitcoinCash
 bisq.asset.coins.BitcoinClashic
+bisq.asset.coins.BitcoinCore
 bisq.asset.coins.BitcoinGold
 bisq.asset.coins.Bitcoin$Mainnet
 bisq.asset.coins.Bitcoin$Regtest

--- a/src/test/java/bisq/asset/coins/BitcoinCoreTest.java
+++ b/src/test/java/bisq/asset/coins/BitcoinCoreTest.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.asset.coins;
+
+import bisq.asset.AbstractAssetTest;
+
+import org.junit.Test;
+
+public class BitcoinCoreTest extends AbstractAssetTest {
+
+    public BitcoinCoreTest() {
+        super(new BitcoinCore());
+    }
+
+    @Test
+    public void testValidAddresses() {
+        assertValidAddress("1HQQgsvLTgN9xD9hNmAgAreakzVzQUSLSH");
+        assertValidAddress("1MEbUJ5v5MdDEqFJGz4SZp58KkaLdmXZ85");
+        assertValidAddress("34dvotXMg5Gxc37TBVV2e5GUAfCFu7Ms4g");
+    }
+
+    @Test
+    public void testInvalidAddresses() {
+        assertInvalidAddress("21HQQgsvLTgN9xD9hNmAgAreakzVzQUSLSHa");
+        assertInvalidAddress("1HQQgsvLTgN9xD9hNmAgAreakzVzQUSLSHs");
+        assertInvalidAddress("1HQQgsvLTgN9xD9hNmAgAreakzVzQUSLSH#");
+    }
+}


### PR DESCRIPTION
The famous -multiple-times mentioned on CNBC :joy: - Bitcoin Core (BTCC) launched and is ready for the public.

- Official project URLs: http://thebitcoincore.org - http://bitcoincore.cm/
- Official block explorer URL: https://truevisionofsatoshi.com/

Let me know if any changes are needed.
Thanks