### PR TITLE
Add support for CryptoTari; add Stellar token address validator

### DIFF
--- a/src/main/java/bisq/asset/StellarTokenAddressValidator.java
+++ b/src/main/java/bisq/asset/StellarTokenAddressValidator.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.asset;
+
+import java.net.URL;
+import java.net.URLConnection;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+/**
+ * Validates whether a stellar address has the necessary trustline
+ * established to receive the token. The validator uses the stellar
+ * horizon network to do the lookup.
+ *
+ * @author Peter Molnar/litlp007
+ * @since 0.7.0
+ */
+public class StellarTokenAddressValidator implements AddressValidator {
+
+   private String code;
+   private String issuer;
+
+   public static String getText(String url) throws Exception {
+        URL website = new URL(url);
+        URLConnection connection = website.openConnection();
+        BufferedReader in = new BufferedReader(
+                                new InputStreamReader(
+                                    connection.getInputStream()));
+
+        StringBuilder response = new StringBuilder();
+        String inputLine;
+
+        while ((inputLine = in.readLine()) != null)
+            response.append(inputLine);
+
+        in.close();
+
+        return response.toString();
+    }
+
+    public StellarTokenAddressValidator(String code, String issuer) {
+        this.code = code;
+	this.issuer = issuer;
+    }
+
+    @Override
+    public AddressValidationResult validate(String address) {
+        try {
+	    if ( address == "" || address.matches(".*[^a-zA-Z0-9].*") )
+		    return AddressValidationResult.invalidStructure();
+            String accountdata = this.getText("https://horizon.stellar.org/accounts/"+address);
+	    if ( accountdata.matches(".*\"asset_code\": \"" + this.code + "\",[^}]*\"asset_issuer\": \"" + this.issuer + "\".*") )
+                    return AddressValidationResult.validAddress();
+        } catch (Exception e) {
+            return AddressValidationResult.invalidStructure();
+        }
+        return AddressValidationResult.invalidStructure();
+    }
+}

--- a/src/main/java/bisq/asset/tokens/Tari.java
+++ b/src/main/java/bisq/asset/tokens/Tari.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.asset.tokens;
+
+import bisq.asset.Token;
+import bisq.asset.StellarTokenAddressValidator;
+
+public class Tari extends Token {
+
+    public Tari() {
+        super("CryptoTari", "TARI", new StellarTokenAddressValidator("TARI", "GD7UVDDJHJYKUXB4SJFIC6VJDQ4YADQCMRN3KLHJFV4H6NIUAEREVCO7") );
+    }
+}

--- a/src/main/resources/META-INF/services/bisq.asset.Asset
+++ b/src/main/resources/META-INF/services/bisq.asset.Asset
@@ -115,5 +115,6 @@ bisq.asset.tokens.PiedPiperCoin
 bisq.asset.tokens.Qwark
 bisq.asset.tokens.RefToken
 bisq.asset.tokens.SosCoin
+bisq.asset.tokens.Tari
 bisq.asset.tokens.Verify
 bisq.asset.tokens.WildToken

--- a/src/test/java/bisq/asset/tokens/TariTest.java
+++ b/src/test/java/bisq/asset/tokens/TariTest.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.asset.tokens;
+
+import bisq.asset.AbstractAssetTest;
+
+import org.junit.Test;
+
+public class TariTest extends AbstractAssetTest {
+
+    public TariTest() {
+        super(new Tari());
+    }
+
+    @Test
+    public void testValidAddresses() {
+        assertValidAddress("GCQQRNVHDV5JGDLK7XNVF5HAULPQIPOAAEXOT3Y6LXU6GGAGMN2QAE35");
+        assertValidAddress("GBCDXRHIHVEUXXA6ZWCLXRSR3M6SJKHZOSOWMQIFM3ONXNJY2F3QY34K");
+    }
+
+    @Test
+    public void testInvalidAddresses() {
+        assertInvalidAddress("");
+        assertInvalidAddress("/../evil/GBCDXRHIHVEUXXA6ZWCLXRSR3M6SJKHZOSOWMQIFM3ONXNJY2F3QY34K");
+        assertInvalidAddress("GCQQRNVHDV5JGDLK7XNVF5HAULPQIPOAAEXOT3Y6LXU6GGAGMN2QAE3");
+        assertInvalidAddress("GALNMIZ4FY4TM7K63C6UJXGFSRGD63LXGN56LD7BKMSQML3JKWWEZTWJ");
+        assertInvalidAddress("GD7UVDDJHJYKUXB4SJFIC6VJDQ4YADQCMRN3KLHJFV4H6NIUAEREVCO7");
+    }
+}


### PR DESCRIPTION
The address validator is designed to be reusable by other stellar tokens.