### PR TITLE
Add support for the CryptoTari stellar token

### DIFF
--- a/src/main/java/bisq/asset/tokens/Tari.java
+++ b/src/main/java/bisq/asset/tokens/Tari.java
@@ -1,0 +1,32 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * CryptoTari is a stellar token issued by account:
+ * GD7UVDDJHJYKUXB4SJFIC6VJDQ4YADQCMRN3KLHJFV4H6NIUAEREVCO7
+ * block explorer: https://stellarchain.io/
+ */
+
+package bisq.asset.tokens;
+
+import bisq.asset.RegexAddressValidator;
+import bisq.asset.Token;
+
+public class Tari extends Token {
+
+    public Tari() {
+        super("CryptoTari", "TARI", new RegexAddressValidator("^[a-zA-Z0-9]{56}$"));
+    }
+}

--- a/src/main/resources/META-INF/services/bisq.asset.Asset
+++ b/src/main/resources/META-INF/services/bisq.asset.Asset
@@ -115,5 +115,6 @@ bisq.asset.tokens.PiedPiperCoin
 bisq.asset.tokens.Qwark
 bisq.asset.tokens.RefToken
 bisq.asset.tokens.SosCoin
+bisq.asset.tokens.Tari
 bisq.asset.tokens.Verify
 bisq.asset.tokens.WildToken

--- a/src/test/java/bisq/asset/tokens/TariTest.java
+++ b/src/test/java/bisq/asset/tokens/TariTest.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.asset.tokens;
+
+import bisq.asset.AbstractAssetTest;
+
+import org.junit.Test;
+
+public class TariTest extends AbstractAssetTest {
+
+    public TariTest() {
+        super(new Tari());
+    }
+
+    @Test
+    public void testValidAddresses() {
+        assertValidAddress("GCQQRNVHDV5JGDLK7XNVF5HAULPQIPOAAEXOT3Y6LXU6GGAGMN2QAE35");
+        assertValidAddress("GBCDXRHIHVEUXXA6ZWCLXRSR3M6SJKHZOSOWMQIFM3ONXNJY2F3QY34K");
+    }
+
+    @Test
+    public void testInvalidAddresses() {
+        assertInvalidAddress("");
+        assertInvalidAddress("/../evil/GBCDXRHIHVEUXXA6ZWCLXRSR3M6SJKHZOSOWMQIFM3ONXDK");
+        assertInvalidAddress("GCQQRNVHDV5JGDLK7XNVF5HAULPQIPOAAEXOT3Y6LXU6GGAGMN2QAE3");
+        assertInvalidAddress("GCQQRNVHDV5JGDLK7XNVF5HAULPQIPOAAEXOT3Y6LXU6GGAGMN2QAE333");
+    }
+}


### PR DESCRIPTION
Block explorer: https://stellarchain.io/
The TARI token is issued by account GD7UVDDJHJYKUXB4SJFIC6VJDQ4YADQCMRN3KLHJFV4H6NIUAEREVCO7 on the stellar network, it's toml file can be accessed at https://cryptotari.io/.well-known/stellar.toml.
This request is a follow-up to request: https://github.com/bisq-network/bisq-assets/pull/19, now with offline address validation.