### PR TITLE
Separate inner classes with two blank lines

### DIFF
--- a/src/main/java/bisq/asset/coins/Angelcoin.java
+++ b/src/main/java/bisq/asset/coins/Angelcoin.java
@@ -28,6 +28,7 @@ public class Angelcoin extends Coin {
         super("Angelcoin", "ALC", new AngelcoinAddressValidator());
     }
 
+
     public static class AngelcoinAddressValidator extends Base58BitcoinAddressValidator {
 
         public AngelcoinAddressValidator() {
@@ -42,6 +43,7 @@ public class Angelcoin extends Coin {
             return super.validate(address);
         }
     }
+
 
     public static class AngelcoinParams extends NetworkParametersAdapter {
 

--- a/src/main/java/bisq/asset/coins/BitCloud.java
+++ b/src/main/java/bisq/asset/coins/BitCloud.java
@@ -44,6 +44,7 @@ public class BitCloud extends Coin {
         }
     }
 
+
     public static class BitCloudParams extends NetworkParametersAdapter {
 
         public BitCloudParams() {

--- a/src/main/java/bisq/asset/coins/BitcoinInstant.java
+++ b/src/main/java/bisq/asset/coins/BitcoinInstant.java
@@ -27,6 +27,7 @@ public class BitcoinInstant extends Coin {
         super("Bitcoin Instant", "BTI", new Base58BitcoinAddressValidator(new BitcoinInstantParams()));
     }
 
+
     public static class BitcoinInstantParams extends NetworkParametersAdapter {
 
         public BitcoinInstantParams() {

--- a/src/main/java/bisq/asset/coins/FuturoCoin.java
+++ b/src/main/java/bisq/asset/coins/FuturoCoin.java
@@ -28,6 +28,7 @@ public class FuturoCoin extends Coin {
         super("FuturoCoin", "FTO", new FuturoCoinValidator());
     }
 
+
     public static class FuturoCoinValidator extends Base58BitcoinAddressValidator {
 
         public FuturoCoinValidator() {
@@ -42,6 +43,7 @@ public class FuturoCoin extends Coin {
             return super.validate(address);
         }
     }
+
 
     public static class FuturoCoinParams extends NetworkParametersAdapter {
 

--- a/src/main/java/bisq/asset/coins/MegaCoin.java
+++ b/src/main/java/bisq/asset/coins/MegaCoin.java
@@ -44,6 +44,7 @@ public class MegaCoin extends Coin {
         }
     }
 
+
     public static class MegaCoinParams extends NetworkParametersAdapter {
 
         public MegaCoinParams() {

--- a/src/main/java/bisq/asset/coins/Phore.java
+++ b/src/main/java/bisq/asset/coins/Phore.java
@@ -44,6 +44,7 @@ public class Phore extends Coin {
         }
     }
 
+
     public static class PhoreParams extends NetworkParametersAdapter {
 
         public PhoreParams() {

--- a/src/main/java/bisq/asset/coins/Wavi.java
+++ b/src/main/java/bisq/asset/coins/Wavi.java
@@ -44,6 +44,7 @@ public class Wavi extends Coin {
         }
     }
 
+
     public static class WaviParams extends NetworkParametersAdapter {
 
         public WaviParams() {

--- a/src/main/java/bisq/asset/coins/WorldMobileCoin.java
+++ b/src/main/java/bisq/asset/coins/WorldMobileCoin.java
@@ -80,6 +80,7 @@ public class WorldMobileCoin extends Coin {
 
     }
 
+
     public static class WorldMobileCoinParams extends NetworkParametersAdapter {
 
         public WorldMobileCoinParams() {
@@ -89,6 +90,7 @@ public class WorldMobileCoin extends Coin {
 
         }
     }
+
 
     private static class WitnessAddress extends VersionedChecksummedBytes {
         static final int PROGRAM_LENGTH_PKH = 20;
@@ -169,6 +171,7 @@ public class WorldMobileCoin extends Coin {
             return out.toByteArray();
         }
     }
+
 
     private static class Bech32 {
         private static final byte[] CHARSET_REV = {

--- a/src/main/java/bisq/asset/coins/Xuez.java
+++ b/src/main/java/bisq/asset/coins/Xuez.java
@@ -45,6 +45,7 @@ public class Xuez extends Coin {
         }
     }
 
+
     public static class XuezParams extends NetworkParametersAdapter {
 
         public XuezParams() {

--- a/src/main/java/bisq/asset/coins/ZeroOneCoin.java
+++ b/src/main/java/bisq/asset/coins/ZeroOneCoin.java
@@ -27,6 +27,7 @@ public class ZeroOneCoin extends Coin {
         super("01coin", "ZOC", new Base58BitcoinAddressValidator(new ZeroOneCoinAddressParams()));
     }
 
+
     public static class ZeroOneCoinAddressParams extends NetworkParametersAdapter {
 
         public ZeroOneCoinAddressParams() {


### PR DESCRIPTION
This is the norm elsewhere throughout the codebase. These classes were outliers.

Heads up, @blabno, as I believe you've reduced a few of these from two lines to one in your review commits.