### PR TITLE
Fix ticker symbol for Cryptonodes (CNMC)

### DIFF
--- a/src/main/java/bisq/asset/coins/Cryptonodes.java
+++ b/src/main/java/bisq/asset/coins/Cryptonodes.java
@@ -25,7 +25,7 @@ import bisq.asset.NetworkParametersAdapter;
 public class Cryptonodes extends Coin {
 
     public Cryptonodes() {
-        super("Cryptonodes", "Cryptonodes", new CryptonodesAddressValidator());
+        super("Cryptonodes", "CNMC", new CryptonodesAddressValidator());
     }
 
 


### PR DESCRIPTION
Previously the implementation did not list a ticker symbol, but rather
listed the asset name where the ticker symbol should have been.

Now the ticker symbol is listed correctly.

See #50