### PR TITLE
List Bitcoin 2 (BTC2)

### DIFF
--- a/src/main/java/bisq/asset/coins/Bitcoin2.java
+++ b/src/main/java/bisq/asset/coins/Bitcoin2.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.asset.coins;
+
+import bisq.asset.Base58BitcoinAddressValidator;
+import bisq.asset.Coin;
+
+public class Bitcoin2 extends Coin {
+
+    public Bitcoin2() {
+        super("Bitcoin 2", "BTC2", new Base58BitcoinAddressValidator());
+    }
+}

--- a/src/main/resources/META-INF/services/bisq.asset.Asset
+++ b/src/main/resources/META-INF/services/bisq.asset.Asset
@@ -7,6 +7,7 @@ bisq.asset.coins.Angelcoin
 bisq.asset.coins.Aquachain
 bisq.asset.coins.Arto
 bisq.asset.coins.BitCloud
+bisq.asset.coins.Bitcoin2
 bisq.asset.coins.BitcoinCash
 bisq.asset.coins.BitcoinClashic
 bisq.asset.coins.BitcoinCore

--- a/src/test/java/bisq/asset/coins/Bitcoin2Test.java
+++ b/src/test/java/bisq/asset/coins/Bitcoin2Test.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.asset.coins;
+
+import bisq.asset.AbstractAssetTest;
+
+import org.junit.Test;
+
+public class Bitcoin2Test extends AbstractAssetTest {
+
+    public Bitcoin2Test() {
+        super(new Bitcoin2());
+    }
+
+    @Test
+    public void testValidAddresses() {
+        assertValidAddress("1Ns5bawVfpHYy6J7qdANasXy2nBTtq23cg");
+        assertValidAddress("1P1WG1SV9AyKsHeGZtdmh8HN6QtCmemMCV");
+        assertValidAddress("1mFiSH3mHL6gdqvRXYW5BgQh9E9vLCpNE");
+    }
+
+    @Test
+    public void testInvalidAddresses() {
+        assertInvalidAddress("21HQQgsvLTgN9xD9hNmAgAreakzVzQUSLSHa");
+        assertInvalidAddress("bc1q2rskr9eey7kvuv53esm8lm2tzmejpr3yzdz8xg");
+        assertInvalidAddress("1HQQgsvLTgN9xD9hNmAgAreakzVzQUSLSH#");
+    }
+}


### PR DESCRIPTION
- Official project URL: https://www.bitc2.org/
- Official block explorer URL: https://www.bitc2.org/block-explorer/

Suggestion: In case of a dispute, the seller of BTC2 should tell the transaction ID (hash). He/she can obtain that easily from the block explorer or from the Bitcoin 2 Core wallet by clicking the Transactions Tab, then clicking the transaction and copy-pasting the transaction ID.